### PR TITLE
Fix mutex fixtures to not require CppUnitTest by default

### DIFF
--- a/src/cppunittest_mutex_fixtures.cpp
+++ b/src/cppunittest_mutex_fixtures.cpp
@@ -3,6 +3,7 @@
 
 // These fixtures are to be used only with CPPUNITTEST
 #define CPP_UNITTEST
+#define USE_CTEST
 
 #include "testrunnerswitcher.h"
 #include "testmutex.h"


### PR DESCRIPTION
Fix mutex fixtures to not require CppUnitTest by default