### PR TITLE
[MrBot] test_watchdog launcher + TEST_LAUNCHER_COMMAND hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,18 @@ option(run_reals_check "set run_reals_check to ON to run reals check (default is
 option(use_installed_dependencies "set use_installed_dependencies to ON to use installed packages instead of building dependencies from submodules" OFF)
 option(use_cppunittest "set use_cppunittest to ON to build CppUnitTest tests on Windows (default is OFF)" OFF)
 
+# test_watchdog: per-test timeout watchdog with minidump capture.
+# When ON (default on Windows), build_exe routes each test via the
+# watchdog launcher, which captures a full-memory minidump if the test
+# exceeds its timeout before killing the process tree.
+# Consuming projects can override by setting use_test_watchdog OFF, or
+# scope the launcher per-folder via TEST_LAUNCHER_DISABLED.
+if(WIN32)
+    option(use_test_watchdog "Wrap integration tests with the test_watchdog launcher (default ON Windows)" ON)
+else()
+    option(use_test_watchdog "Wrap integration tests with the test_watchdog launcher (Windows only)" OFF)
+endif()
+
 #bring in dependencies
 #do not add or build any tests of the dependencies
 set(original_run_e2e_tests ${run_e2e_tests})
@@ -111,6 +123,15 @@ set_target_properties(testrunnerswitcher
                FOLDER "test_tools")
 
 add_subdirectory(build_functions)
+
+# Build the test_watchdog tool before test_projects so that build_exe's
+# launcher injection (when use_test_watchdog is ON) can resolve the
+# target's $<TARGET_FILE:test_watchdog>. Gated on WIN32 because dbghelp
+# is Windows-only.
+if(WIN32 AND ${use_test_watchdog})
+    add_subdirectory(tools/test_watchdog)
+endif()
+
 add_subdirectory(test_projects)
 
 if(${run_reals_check})

--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -328,7 +328,30 @@ function(build_exe whatIsBuilding solution_folder custom_main)
     #register the exe with ctest's list of tests
     #WORKING_DIRECTORY is set to the exe's output folder so that DbgHelp (SymInitialize)
     #can find PDB files when the test is run on a different agent than where it was built.
-    add_test(NAME ${whatIsBuilding} COMMAND ${whatIsBuilding}_exe_${CMAKE_PROJECT_NAME} WORKING_DIRECTORY $<TARGET_FILE_DIR:${whatIsBuilding}_exe_${CMAKE_PROJECT_NAME}>)
+    #
+    #If TEST_LAUNCHER_COMMAND is set (typically by a consuming project's
+    #build_test_folder scoping), prepend it to the test command. This lets
+    #a consumer wrap tests with e.g. a per-test watchdog/timeout tool that
+    #captures a dump on hang. When wrapped, also set an explicit CTest
+    #TIMEOUT large enough to let the launcher run its own timeout+dump
+    #budget before CTest would otherwise preempt the wrapper.
+    if(DEFINED TEST_LAUNCHER_COMMAND AND TEST_LAUNCHER_COMMAND)
+        add_test(NAME ${whatIsBuilding}
+                 COMMAND ${TEST_LAUNCHER_COMMAND} $<TARGET_FILE:${whatIsBuilding}_exe_${CMAKE_PROJECT_NAME}>
+                 WORKING_DIRECTORY $<TARGET_FILE_DIR:${whatIsBuilding}_exe_${CMAKE_PROJECT_NAME}>)
+
+        if(NOT DEFINED TEST_LAUNCHER_TIMEOUT_SECONDS)
+            set(TEST_LAUNCHER_TIMEOUT_SECONDS 1200)
+        endif()
+        if(NOT DEFINED TEST_LAUNCHER_DUMP_TIMEOUT_SECONDS)
+            set(TEST_LAUNCHER_DUMP_TIMEOUT_SECONDS 180)
+        endif()
+        math(EXPR _ctest_timeout
+            "${TEST_LAUNCHER_TIMEOUT_SECONDS} + ${TEST_LAUNCHER_DUMP_TIMEOUT_SECONDS} + 60")
+        set_tests_properties(${whatIsBuilding} PROPERTIES TIMEOUT ${_ctest_timeout})
+    else()
+        add_test(NAME ${whatIsBuilding} COMMAND ${whatIsBuilding}_exe_${CMAKE_PROJECT_NAME} WORKING_DIRECTORY $<TARGET_FILE_DIR:${whatIsBuilding}_exe_${CMAKE_PROJECT_NAME}>)
+    endif()
 
     if(UNIX) #LINUX OR APPLE
         if(${run_valgrind} OR ${run_helgrind} OR ${run_drd})
@@ -368,6 +391,20 @@ function(build_test_folder test_folder)
         set(multiValueArgs) #no multi value args
 
         cmake_parse_arguments("arg" "${options}" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}) #"arg" is the prefix added to variables detected by cmake_parse_arguments
+
+        # Scope test wrapping (e.g. timeout watchdog) to integration tests only.
+        # The consuming project sets TEST_LAUNCHER_COMMAND_INT to a CMake list
+        # like "<watchdog_exe>;--timeout-seconds;1200;--dump-dir;<path>;--".
+        # Sub-trees can opt out (e.g. the watchdog's own self-tests) by setting
+        # TEST_LAUNCHER_DISABLED.
+        if(("${test_folder}" MATCHES ".*int.*")
+           AND DEFINED TEST_LAUNCHER_COMMAND_INT
+           AND TEST_LAUNCHER_COMMAND_INT
+           AND NOT TEST_LAUNCHER_DISABLED)
+            set(TEST_LAUNCHER_COMMAND ${TEST_LAUNCHER_COMMAND_INT})
+        else()
+            set(TEST_LAUNCHER_COMMAND "")
+        endif()
 
         set(building exe)
         add_subdirectory(${test_folder} ${test_folder}/${arg_BINARY_DIR}/${building})

--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -449,3 +449,33 @@ function(build_test_artifacts_with_custom_main whatIsBuilding solution_folder )
         MESSAGE(FATAL_ERROR "not an expected value: building=${building} test_folder=${test_folder} ARGN=${ARGN}")
     endif()
 endfunction()
+
+#
+# set_test_watchdog_timeout: configure a per-test watchdog timeout for an
+# already-registered ctest test. Sets both the environment override
+# (TEST_WATCHDOG_TIMEOUT_SECONDS - applied by the watchdog) and the
+# matching CTest TIMEOUT property (so CTest does not preempt the
+# watchdog before dump capture completes).
+#
+# Usage (consuming repo, AFTER build_test_folder has registered the test):
+#   set_test_watchdog_timeout(my_int_test 600)
+#
+# This function is intended to be called from inside a test directory's
+# CMakeLists.txt right after build_test_artifacts. With use_cppunittest=ON,
+# build_test_folder processes the test directory twice (exe + dll passes);
+# only the exe pass actually registers a ctest test via add_test. Skip
+# silently on non-exe passes so set_property doesn't error out on a test
+# that exists only in the sibling binary-dir scope.
+function(set_test_watchdog_timeout test_name seconds)
+    if(DEFINED building AND NOT "${building}" STREQUAL "exe")
+        return()
+    endif()
+    if(NOT DEFINED TEST_LAUNCHER_DUMP_TIMEOUT_SECONDS)
+        set(TEST_LAUNCHER_DUMP_TIMEOUT_SECONDS 180)
+    endif()
+    set_property(TEST ${test_name} APPEND PROPERTY
+        ENVIRONMENT "TEST_WATCHDOG_TIMEOUT_SECONDS=${seconds}")
+    math(EXPR _twd_ctest_timeout
+        "${seconds} + ${TEST_LAUNCHER_DUMP_TIMEOUT_SECONDS} + 60")
+    set_property(TEST ${test_name} PROPERTY TIMEOUT ${_twd_ctest_timeout})
+endfunction()

--- a/test_projects/CMakeLists.txt
+++ b/test_projects/CMakeLists.txt
@@ -8,3 +8,15 @@ build_test_folder(test_project_perf)
 build_test_folder(test_project_with_custom_main_ut)
 build_test_folder(ctest_2_cppunittest_ut)
 build_test_folder(parameterized_tests_ut)
+
+# Self-tests for the test_watchdog launcher (plain Win32 exe, not a
+# c-testrunnerswitcher test suite). Must NOT be wrapped by the watchdog
+# itself — that would cause infinite recursion if a self-test timed out.
+# TEST_LAUNCHER_DISABLED prevents build_test_folder from injecting the
+# launcher inside this subtree; the test_watchdog_int subdir doesn't go
+# through build_test_folder anyway (it uses plain add_test) but setting
+# the variable here is harmless and self-documenting.
+if(WIN32 AND ${use_test_watchdog} AND ${run_int_tests})
+    set(TEST_LAUNCHER_DISABLED ON)
+    add_subdirectory(test_watchdog_int)
+endif()

--- a/test_projects/test_watchdog_int/CMakeLists.txt
+++ b/test_projects/test_watchdog_int/CMakeLists.txt
@@ -1,0 +1,43 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# Self-tests for test_watchdog (plain Win32 exe; ctest framework not used
+# here because the watchdog deliberately has no project-library deps and
+# we want a self-contained pass/fail exe).
+#
+# Windows-only: the watchdog tool itself is Windows-only.
+# Skip if test_watchdog target was not built (e.g. use_test_watchdog=OFF).
+
+if(NOT WIN32)
+    return()
+endif()
+if(NOT TARGET test_watchdog)
+    return()
+endif()
+
+add_executable(test_watchdog_int test_watchdog_int.c)
+
+set_target_properties(test_watchdog_int PROPERTIES
+    FOLDER "test_tools")
+
+# Land in the same directory as test_watchdog.exe so the self-test can
+# resolve the watchdog at runtime via GetModuleFileNameW + path join.
+set_target_properties(test_watchdog_int PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY $<TARGET_FILE_DIR:test_watchdog>)
+
+add_dependencies(test_watchdog_int test_watchdog)
+
+# VLD bytecode + banner would pollute test output. The watchdog itself
+# also opts out via copy_disable_vld_ini; do the same here.
+if(${use_vld})
+    if(COMMAND copy_disable_vld_ini)
+        copy_disable_vld_ini(test_watchdog_int $<TARGET_FILE_DIR:test_watchdog_int>)
+    endif()
+endif()
+
+# Register the self-test with CMake's ctest. Do NOT route through the
+# watchdog launcher (set TEST_LAUNCHER_DISABLED in the parent so
+# build_test_folder also opts out for this subtree).
+add_test(NAME test_watchdog_int
+         COMMAND test_watchdog_int
+         WORKING_DIRECTORY $<TARGET_FILE_DIR:test_watchdog_int>)

--- a/test_projects/test_watchdog_int/test_watchdog_int.c
+++ b/test_projects/test_watchdog_int/test_watchdog_int.c
@@ -1,0 +1,468 @@
+// Copyright (c) Microsoft. All rights reserved.
+//
+// Integration tests for test_watchdog.exe.
+//
+// Implemented as a plain Win32 console application (NOT a ctest-framework
+// suite) because:
+//   (a) the watchdog deliberately has no project-library dependencies, and
+//   (b) we want a self-contained test exe that can be invoked directly by
+//       CMake's `ctest` with a simple pass/fail exit code, without dragging
+//       in c-logging or umock-c just to print test names.
+//
+// Each test_* function returns 0 on success, nonzero on failure. main()
+// runs them in order, prints concise PASS/FAIL lines to stderr, and exits
+// with the number of failures (clamped to 1..127).
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <wchar.h>
+
+#include <windows.h>
+
+#define TWD_EXIT_TIMEOUT    124
+#define TWD_EXIT_USAGE      2
+#define MDMP_SIGNATURE      0x504d444d
+
+// Resolved at runtime in main() from the path of this test exe — the
+// watchdog binary lives alongside it. Resolving at runtime (instead of
+// baking a build-time path via a CMake-defined macro) is essential for
+// CI: build agent and test agent generally have different work-directory
+// paths, so a compile-time absolute path would be wrong on the test
+// agent.
+static wchar_t TWD_EXE[MAX_PATH * 2];
+static wchar_t g_test_root[MAX_PATH];
+
+// ----- assertion helpers -----------------------------------------------------
+
+#define TEST_FAIL_FMT(fmt, ...) \
+    do { \
+        fprintf(stderr, "    FAIL %s:%d: " fmt "\n", __FILE__, __LINE__, __VA_ARGS__); \
+        return 1; \
+    } while (0)
+
+#define EXPECT_EQ_INT(actual, expected) \
+    do { \
+        int _a = (actual); int _e = (expected); \
+        if (_a != _e) { \
+            fprintf(stderr, "    FAIL %s:%d: expected %d, got %d\n", __FILE__, __LINE__, _e, _a); \
+            return 1; \
+        } \
+    } while (0)
+
+#define EXPECT_TRUE(expr) \
+    do { \
+        if (!(expr)) { \
+            fprintf(stderr, "    FAIL %s:%d: '%s' was false\n", __FILE__, __LINE__, #expr); \
+            return 1; \
+        } \
+    } while (0)
+
+// ----- support utilities -----------------------------------------------------
+
+static void make_test_subdir(const wchar_t* test_name, wchar_t* out, size_t out_chars)
+{
+    (void)swprintf_s(out, out_chars, L"%ls\\%ls", g_test_root, test_name);
+    (void)CreateDirectoryW(out, NULL);
+    // wipe any leftovers from a prior run
+    wchar_t pattern[MAX_PATH * 2];
+    (void)swprintf_s(pattern, sizeof(pattern) / sizeof(pattern[0]), L"%ls\\*", out);
+    WIN32_FIND_DATAW fd;
+    HANDLE h = FindFirstFileW(pattern, &fd);
+    if (h != INVALID_HANDLE_VALUE)
+    {
+        do
+        {
+            if ((fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
+            {
+                wchar_t fp[MAX_PATH * 2];
+                (void)swprintf_s(fp, sizeof(fp) / sizeof(fp[0]), L"%ls\\%ls", out, fd.cFileName);
+                (void)DeleteFileW(fp);
+            }
+        } while (FindNextFileW(h, &fd));
+        FindClose(h);
+    }
+}
+
+// Quote a single argument per Win32 CommandLineToArgvW rules and append to dst.
+static void append_arg(wchar_t* dst, size_t dst_chars, const wchar_t* arg)
+{
+    size_t cur = wcslen(dst);
+    if (cur > 0)
+    {
+        if (cur + 2 < dst_chars) { dst[cur++] = L' '; dst[cur] = L'\0'; }
+    }
+    bool needs_quote = (arg[0] == L'\0') || (wcspbrk(arg, L" \t\"") != NULL);
+    if (!needs_quote)
+    {
+        (void)wcscat_s(dst, dst_chars, arg);
+        return;
+    }
+    if (cur + 1 < dst_chars) { dst[cur++] = L'"'; dst[cur] = L'\0'; }
+    size_t bs = 0;
+    for (const wchar_t* p = arg; *p != L'\0'; p++)
+    {
+        cur = wcslen(dst);
+        if (*p == L'\\')
+        {
+            bs++;
+            if (cur + 1 < dst_chars) { dst[cur++] = L'\\'; dst[cur] = L'\0'; }
+        }
+        else if (*p == L'"')
+        {
+            for (size_t k = 0; k < bs + 1; k++)
+            {
+                cur = wcslen(dst);
+                if (cur + 1 < dst_chars) { dst[cur++] = L'\\'; dst[cur] = L'\0'; }
+            }
+            cur = wcslen(dst);
+            if (cur + 1 < dst_chars) { dst[cur++] = L'"'; dst[cur] = L'\0'; }
+            bs = 0;
+        }
+        else
+        {
+            if (cur + 1 < dst_chars) { dst[cur++] = *p; dst[cur] = L'\0'; }
+            bs = 0;
+        }
+    }
+    for (size_t k = 0; k < bs; k++)
+    {
+        cur = wcslen(dst);
+        if (cur + 1 < dst_chars) { dst[cur++] = L'\\'; dst[cur] = L'\0'; }
+    }
+    cur = wcslen(dst);
+    if (cur + 1 < dst_chars) { dst[cur++] = L'"'; dst[cur] = L'\0'; }
+}
+
+// Spawn TWD_EXE with the given arguments. Returns the exit code, or -1 if
+// the watchdog itself failed to spawn or did not exit within wait_seconds.
+static int run_watchdog(int argc, const wchar_t** argv, uint32_t wait_seconds)
+{
+    wchar_t cmdline[4096];
+    cmdline[0] = L'\0';
+    append_arg(cmdline, sizeof(cmdline) / sizeof(cmdline[0]), TWD_EXE);
+    for (int i = 0; i < argc; i++)
+    {
+        append_arg(cmdline, sizeof(cmdline) / sizeof(cmdline[0]), argv[i]);
+    }
+
+    STARTUPINFOW si;
+    memset(&si, 0, sizeof(si));
+    si.cb = sizeof(si);
+
+    PROCESS_INFORMATION pi;
+    memset(&pi, 0, sizeof(pi));
+
+    BOOL ok = CreateProcessW(NULL, cmdline, NULL, NULL, FALSE,
+        CREATE_NO_WINDOW, NULL, NULL, &si, &pi);
+    if (!ok)
+    {
+        (void)fprintf(stderr, "    CreateProcessW failed: %lu cmdline='%ls'\n",
+            (unsigned long)GetLastError(), cmdline);
+        return -1;
+    }
+
+    DWORD wait = WaitForSingleObject(pi.hProcess, wait_seconds * 1000u);
+    int rc = -1;
+    if (wait == WAIT_OBJECT_0)
+    {
+        DWORD exit_code = 0;
+        if (GetExitCodeProcess(pi.hProcess, &exit_code))
+        {
+            rc = (int)exit_code;
+        }
+    }
+    else if (wait == WAIT_TIMEOUT)
+    {
+        (void)fprintf(stderr, "    watchdog did not exit within %us; killing\n",
+            wait_seconds);
+        (void)TerminateProcess(pi.hProcess, 1);
+        (void)WaitForSingleObject(pi.hProcess, 5000);
+    }
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    return rc;
+}
+
+static int count_dmp_files(const wchar_t* dir)
+{
+    wchar_t pattern[MAX_PATH * 2];
+    (void)swprintf_s(pattern, sizeof(pattern) / sizeof(pattern[0]), L"%ls\\*.dmp", dir);
+    WIN32_FIND_DATAW fd;
+    HANDLE h = FindFirstFileW(pattern, &fd);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        return 0;
+    }
+    int count = 0;
+    do { count++; } while (FindNextFileW(h, &fd));
+    FindClose(h);
+    return count;
+}
+
+static bool find_first_dmp(const wchar_t* dir, wchar_t* out, size_t out_chars)
+{
+    wchar_t pattern[MAX_PATH * 2];
+    (void)swprintf_s(pattern, sizeof(pattern) / sizeof(pattern[0]), L"%ls\\*.dmp", dir);
+    WIN32_FIND_DATAW fd;
+    HANDLE h = FindFirstFileW(pattern, &fd);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        out[0] = L'\0';
+        return false;
+    }
+    (void)swprintf_s(out, out_chars, L"%ls\\%ls", dir, fd.cFileName);
+    FindClose(h);
+    return true;
+}
+
+static bool verify_minidump_magic(const wchar_t* path)
+{
+    HANDLE h = CreateFileW(path, GENERIC_READ, FILE_SHARE_READ, NULL,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h == INVALID_HANDLE_VALUE) return false;
+    uint32_t magic = 0;
+    DWORD read = 0;
+    BOOL ok = ReadFile(h, &magic, sizeof(magic), &read, NULL);
+    CloseHandle(h);
+    return (ok && (read == sizeof(magic)) && (magic == MDMP_SIGNATURE));
+}
+
+// ----- test cases ------------------------------------------------------------
+
+static int test_successful_child_returns_zero(void)
+{
+    wchar_t dump_dir[MAX_PATH];
+    make_test_subdir(L"successful_child", dump_dir, sizeof(dump_dir) / sizeof(dump_dir[0]));
+
+    const wchar_t* args[] = {
+        L"--timeout-seconds", L"30",
+        L"--dump-dir", dump_dir,
+        L"--", L"cmd.exe", L"/c", L"exit 0"
+    };
+    int rc = run_watchdog((int)(sizeof(args) / sizeof(args[0])), args, 60);
+    EXPECT_EQ_INT(rc, 0);
+    EXPECT_EQ_INT(count_dmp_files(dump_dir), 0);
+    return 0;
+}
+
+static int test_propagates_nonzero_child_exit_code(void)
+{
+    wchar_t dump_dir[MAX_PATH];
+    make_test_subdir(L"nonzero_child", dump_dir, sizeof(dump_dir) / sizeof(dump_dir[0]));
+
+    const wchar_t* args[] = {
+        L"--timeout-seconds", L"30",
+        L"--dump-dir", dump_dir,
+        L"--", L"cmd.exe", L"/c", L"exit 42"
+    };
+    int rc = run_watchdog((int)(sizeof(args) / sizeof(args[0])), args, 60);
+    EXPECT_EQ_INT(rc, 42);
+    EXPECT_EQ_INT(count_dmp_files(dump_dir), 0);
+    return 0;
+}
+
+static int test_times_out_and_captures_minidump(void)
+{
+    wchar_t dump_dir[MAX_PATH];
+    make_test_subdir(L"timeout_dump", dump_dir, sizeof(dump_dir) / sizeof(dump_dir[0]));
+
+    const wchar_t* args[] = {
+        L"--timeout-seconds", L"2",
+        L"--dump-timeout-seconds", L"60",
+        L"--dump-dir", dump_dir,
+        L"--", L"cmd.exe", L"/c", L"ping -n 60 127.0.0.1 > nul"
+    };
+    int rc = run_watchdog((int)(sizeof(args) / sizeof(args[0])), args, 120);
+    EXPECT_EQ_INT(rc, TWD_EXIT_TIMEOUT);
+
+    int n = count_dmp_files(dump_dir);
+    if (n != 1)
+    {
+        TEST_FAIL_FMT("expected 1 dump file, got %d", n);
+    }
+
+    wchar_t dump_path[MAX_PATH];
+    EXPECT_TRUE(find_first_dmp(dump_dir, dump_path, sizeof(dump_path) / sizeof(dump_path[0])));
+    EXPECT_TRUE(verify_minidump_magic(dump_path));
+    return 0;
+}
+
+static int test_env_timeout_override_takes_precedence(void)
+{
+    wchar_t dump_dir[MAX_PATH];
+    make_test_subdir(L"env_override", dump_dir, sizeof(dump_dir) / sizeof(dump_dir[0]));
+
+    EXPECT_TRUE(SetEnvironmentVariableW(L"TEST_WATCHDOG_TIMEOUT_SECONDS", L"2"));
+
+    const wchar_t* args[] = {
+        L"--timeout-seconds", L"60",
+        L"--dump-timeout-seconds", L"60",
+        L"--dump-dir", dump_dir,
+        L"--", L"cmd.exe", L"/c", L"ping -n 30 127.0.0.1 > nul"
+    };
+
+    DWORD start = GetTickCount();
+    int rc = run_watchdog((int)(sizeof(args) / sizeof(args[0])), args, 90);
+    DWORD elapsed_ms = GetTickCount() - start;
+
+    (void)SetEnvironmentVariableW(L"TEST_WATCHDOG_TIMEOUT_SECONDS", NULL);
+
+    EXPECT_EQ_INT(rc, TWD_EXIT_TIMEOUT);
+    if (elapsed_ms >= 25000)
+    {
+        TEST_FAIL_FMT("watchdog took %lu ms; env override appears not to have applied",
+            (unsigned long)elapsed_ms);
+    }
+    return 0;
+}
+
+static int test_rejects_missing_dump_dir(void)
+{
+    const wchar_t* args[] = {
+        L"--timeout-seconds", L"30",
+        L"--", L"cmd.exe", L"/c", L"exit 0"
+    };
+    int rc = run_watchdog((int)(sizeof(args) / sizeof(args[0])), args, 30);
+    EXPECT_EQ_INT(rc, TWD_EXIT_USAGE);
+    return 0;
+}
+
+static int test_dump_tree_captures_descendant_dumps(void)
+{
+    wchar_t dump_dir[MAX_PATH];
+    make_test_subdir(L"dump_tree", dump_dir, sizeof(dump_dir) / sizeof(dump_dir[0]));
+
+    const wchar_t* args[] = {
+        L"--timeout-seconds", L"3",
+        L"--dump-timeout-seconds", L"60",
+        L"--dump-tree",
+        L"--dump-dir", dump_dir,
+        L"--", L"cmd.exe", L"/c",
+        L"start /B cmd.exe /c \"ping -n 60 127.0.0.1 > nul\" & ping -n 60 127.0.0.1 > nul"
+    };
+    int rc = run_watchdog((int)(sizeof(args) / sizeof(args[0])), args, 180);
+    EXPECT_EQ_INT(rc, TWD_EXIT_TIMEOUT);
+
+    int n = count_dmp_files(dump_dir);
+    if (n < 2)
+    {
+        TEST_FAIL_FMT("expected at least 2 dumps with --dump-tree, got %d", n);
+    }
+    return 0;
+}
+
+// ----- main ------------------------------------------------------------------
+
+typedef int (*test_fn)(void);
+typedef struct
+{
+    const char* name;
+    test_fn     fn;
+} TEST_CASE;
+
+static const TEST_CASE g_tests[] =
+{
+    { "successful_child_returns_zero",          test_successful_child_returns_zero },
+    { "propagates_nonzero_child_exit_code",     test_propagates_nonzero_child_exit_code },
+    { "times_out_and_captures_minidump",        test_times_out_and_captures_minidump },
+    { "env_timeout_override_takes_precedence",  test_env_timeout_override_takes_precedence },
+    { "rejects_missing_dump_dir",               test_rejects_missing_dump_dir },
+    { "dump_tree_captures_descendant_dumps",    test_dump_tree_captures_descendant_dumps },
+};
+
+int main(int argc, char* argv[])
+{
+    setvbuf(stderr, NULL, _IONBF, 0);
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    const char* filter = (argc > 1) ? argv[1] : NULL;
+
+    // Resolve TWD_EXE as <directory_of_this_exe>\test_watchdog.exe. The
+    // build system places both binaries side-by-side in the test config
+    // output directory, and at run time the test agent's checkout path
+    // typically differs from the build agent's — so a compile-time path
+    // baked via a macro would be wrong on the test agent.
+    DWORD self_len = GetModuleFileNameW(NULL, TWD_EXE,
+        (DWORD)(sizeof(TWD_EXE) / sizeof(TWD_EXE[0])));
+    if (self_len == 0 || self_len >= sizeof(TWD_EXE) / sizeof(TWD_EXE[0]))
+    {
+        (void)fprintf(stderr, "GetModuleFileNameW failed: %lu\n",
+            (unsigned long)GetLastError());
+        return 1;
+    }
+    wchar_t* last_sep = TWD_EXE;
+    for (wchar_t* p = TWD_EXE; *p != L'\0'; p++)
+    {
+        if (*p == L'\\' || *p == L'/')
+        {
+            last_sep = p + 1;
+        }
+    }
+    *last_sep = L'\0';
+    if (wcscat_s(TWD_EXE, sizeof(TWD_EXE) / sizeof(TWD_EXE[0]),
+        L"test_watchdog.exe") != 0)
+    {
+        (void)fprintf(stderr, "Failed to build TWD_EXE path\n");
+        return 1;
+    }
+    if (GetFileAttributesW(TWD_EXE) == INVALID_FILE_ATTRIBUTES)
+    {
+        (void)fprintf(stderr, "Watchdog not found at '%ls' (GetLastError=%lu)\n",
+            TWD_EXE, (unsigned long)GetLastError());
+        return 1;
+    }
+
+    wchar_t tmp[MAX_PATH];
+    DWORD n = GetTempPathW((DWORD)(sizeof(tmp) / sizeof(tmp[0])), tmp);
+    if (n == 0 || n >= sizeof(tmp) / sizeof(tmp[0]))
+    {
+        (void)fprintf(stderr, "GetTempPathW failed\n");
+        return 1;
+    }
+    (void)swprintf_s(g_test_root, sizeof(g_test_root) / sizeof(g_test_root[0]),
+        L"%lstwd_int_%lu", tmp, (unsigned long)GetCurrentProcessId());
+    (void)CreateDirectoryW(g_test_root, NULL);
+
+    const size_t test_count = sizeof(g_tests) / sizeof(g_tests[0]);
+    size_t failed = 0;
+    size_t ran = 0;
+
+    (void)fprintf(stderr, " === Executing test suite test_watchdog_int (%zu tests) ===\n"
+                          " === Watchdog binary: %ls ===\n",
+        test_count, TWD_EXE);
+
+    for (size_t i = 0; i < test_count; i++)
+    {
+        const TEST_CASE* tc = &g_tests[i];
+        if (filter != NULL && filter[0] != '\0' && strcmp(filter, tc->name) != 0)
+        {
+            continue;
+        }
+        ran++;
+        (void)fprintf(stderr, "Executing test %s ...\n", tc->name);
+        int rc = tc->fn();
+        if (rc == 0)
+        {
+            (void)fprintf(stderr, "  Test %s result = Succeeded.\n", tc->name);
+        }
+        else
+        {
+            failed++;
+            (void)fprintf(stderr, "  Test %s result = !!! FAILED !!!\n", tc->name);
+        }
+    }
+
+    (void)fprintf(stderr, "%zu tests ran, %zu failed, %zu succeeded.\n",
+        ran, failed, ran - failed);
+
+    if (ran == 0)
+    {
+        (void)fprintf(stderr, "no tests matched filter '%s'\n", filter ? filter : "(none)");
+        return 1;
+    }
+    if (failed > 127) failed = 127;
+    return (int)failed;
+}

--- a/tools/test_watchdog/CMakeLists.txt
+++ b/tools/test_watchdog/CMakeLists.txt
@@ -1,0 +1,42 @@
+#Copyright (c) Microsoft. All rights reserved.
+#Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+# test_watchdog: per-test timeout watchdog that captures a full-memory
+# minidump before killing a hung test process. Used by the build_exe
+# launcher hook in c-testrunnerswitcher's build_functions when
+# `use_test_watchdog` is ON.
+#
+# Self-contained on purpose: depends only on Windows system libraries
+# (kernel32 via the CRT, dbghelp, psapi). No project libraries — this
+# lets the watchdog build even when the rest of a consuming repo is
+# broken, and avoids circular dependencies when wrapping the very test
+# binaries it would normally link to.
+
+if(NOT WIN32)
+    return()
+endif()
+
+add_executable(test_watchdog test_watchdog.c)
+
+# Use the wide-character entry point.
+if(MSVC)
+    set_target_properties(test_watchdog PROPERTIES
+        LINK_FLAGS "/ENTRY:wmainCRTStartup")
+endif()
+
+target_link_libraries(test_watchdog
+    dbghelp
+    psapi)
+
+set_target_properties(test_watchdog PROPERTIES
+    FOLDER "test_tools")
+
+# Disable VLD for this tool: it's a small Win32 wrapper, the VLD banner
+# would pollute ctest -V output, and we explicitly want the watchdog to
+# remain lean and self-contained. copy_disable_vld_ini comes from
+# c-build-tools and is only defined when use_vld is ON.
+if(${use_vld})
+    if(COMMAND copy_disable_vld_ini)
+        copy_disable_vld_ini(test_watchdog $<TARGET_FILE_DIR:test_watchdog>)
+    endif()
+endif()

--- a/tools/test_watchdog/test_watchdog.c
+++ b/tools/test_watchdog/test_watchdog.c
@@ -1,0 +1,929 @@
+// Copyright (c) Microsoft. All rights reserved.
+//
+// test_watchdog: wraps a child test process with a timeout. On timeout,
+// captures a full-memory minidump via a helper subprocess (the same binary
+// in --dump-helper mode) before terminating the process tree.
+//
+// Self-contained: depends only on kernel32, dbghelp, psapi. No project libs.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <wchar.h>
+#include <time.h>
+
+#include <windows.h>
+#include <psapi.h>
+#include <dbghelp.h>
+#include <shellapi.h>
+
+#define TWD_DEFAULT_TIMEOUT_SECONDS         1200u
+#define TWD_DEFAULT_DUMP_TIMEOUT_SECONDS    180u
+#define TWD_DEFAULT_MAX_DUMP_BYTES_GB       4u
+#define TWD_DEFAULT_MAX_DUMP_BYTES          ((uint64_t)TWD_DEFAULT_MAX_DUMP_BYTES_GB * 1024ull * 1024ull * 1024ull)
+
+#define TWD_MIN_TIMEOUT_SECONDS             1u
+#define TWD_MAX_TIMEOUT_SECONDS             7200u
+
+#define TWD_EXIT_TIMEOUT                    124
+#define TWD_EXIT_CANCELLED                  130
+#define TWD_EXIT_USAGE                      2
+#define TWD_EXIT_SPAWN_FAILED               125
+
+#define TWD_FULL_DUMP_FLAGS \
+    (MiniDumpWithFullMemory | \
+     MiniDumpWithHandleData | \
+     MiniDumpWithThreadInfo | \
+     MiniDumpWithUnloadedModules | \
+     MiniDumpWithFullMemoryInfo)
+
+#define TWD_TRIAGE_DUMP_FLAGS \
+    (MiniDumpWithHandleData | \
+     MiniDumpWithThreadInfo | \
+     MiniDumpWithUnloadedModules)
+
+typedef struct TWD_CONFIG_TAG
+{
+    uint32_t timeout_seconds;
+    uint32_t dump_timeout_seconds;
+    uint64_t max_dump_bytes;
+    bool     dump_tree;
+    bool     full_dump;
+    wchar_t* dump_dir;        // owned
+    wchar_t* child_exe;       // owned (full path)
+    int      child_argc;
+    wchar_t** child_argv;     // points into argv array; not owned
+} TWD_CONFIG;
+
+// Global state so the console control handler can terminate the job
+// promptly on Ctrl-C / pipeline cancellation.
+static HANDLE g_job_handle = NULL;
+static volatile LONG g_cancelled = 0;
+
+static void twd_log(const char* level, const wchar_t* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    (void)fprintf(stderr, "##[%s] test_watchdog: ", level);
+    (void)vfwprintf(stderr, fmt, args);
+    (void)fprintf(stderr, "\n");
+    (void)fflush(stderr);
+    va_end(args);
+}
+
+#define TWD_LOG_INFO(...)    twd_log("section", __VA_ARGS__)
+#define TWD_LOG_WARNING(...) twd_log("warning", __VA_ARGS__)
+#define TWD_LOG_ERROR(...)   twd_log("error",   __VA_ARGS__)
+
+static void print_usage(void)
+{
+    (void)fprintf(stderr,
+        "test_watchdog - wrap a test process with a timeout, capturing a\n"
+        "                minidump before killing on hang.\n"
+        "\n"
+        "Usage:\n"
+        "  test_watchdog [options] -- <child_exe> [args...]\n"
+        "\n"
+        "Options:\n"
+        "  --timeout-seconds N         Kill child after N seconds (default %u).\n"
+        "  --dump-dir <path>           Where to write minidumps (required).\n"
+        "  --dump-timeout-seconds M    Max seconds for dump capture (default %u).\n"
+        "  --max-dump-bytes B          Skip dump if dump-dir already exceeds B bytes\n"
+        "                              (default %u GiB).\n"
+        "  --dump-tree                 Also dump descendant processes (default off).\n"
+        "  --no-full-dump              Capture triage dump instead of full memory.\n"
+        "  -h, --help                  Show this help.\n"
+        "\n"
+        "Environment overrides (override CLI when set and valid):\n"
+        "  TEST_WATCHDOG_TIMEOUT_SECONDS\n"
+        "  TEST_WATCHDOG_DUMP_DIR\n"
+        "  TEST_WATCHDOG_FULL_DUMP=0   - request triage dump\n"
+        "\n"
+        "Internal helper mode (do not invoke directly):\n"
+        "  test_watchdog --dump-helper <pid> <dump_path> <flags_hex>\n"
+        "\n"
+        "Exit codes:\n"
+        "  <child code>  on normal child completion\n"
+        "  %d            on watchdog timeout (dump attempted, tree killed)\n"
+        "  %d            on Ctrl-C / cancellation\n"
+        "  %d            on usage error\n"
+        "  %d            on spawn failure\n",
+        TWD_DEFAULT_TIMEOUT_SECONDS,
+        TWD_DEFAULT_DUMP_TIMEOUT_SECONDS,
+        TWD_DEFAULT_MAX_DUMP_BYTES_GB,
+        TWD_EXIT_TIMEOUT, TWD_EXIT_CANCELLED,
+        TWD_EXIT_USAGE, TWD_EXIT_SPAWN_FAILED);
+    (void)fflush(stderr);
+}
+
+static bool parse_uint32(const wchar_t* s, uint32_t* out)
+{
+    if ((s == NULL) || (s[0] == L'\0'))
+    {
+        return false;
+    }
+    wchar_t* end = NULL;
+    unsigned long v = wcstoul(s, &end, 10);
+    if ((end == NULL) || (*end != L'\0') || (v > 0xFFFFFFFFu))
+    {
+        return false;
+    }
+    *out = (uint32_t)v;
+    return true;
+}
+
+static bool parse_uint64(const wchar_t* s, uint64_t* out)
+{
+    if ((s == NULL) || (s[0] == L'\0'))
+    {
+        return false;
+    }
+    wchar_t* end = NULL;
+    unsigned long long v = _wcstoui64(s, &end, 10);
+    if ((end == NULL) || (*end != L'\0'))
+    {
+        return false;
+    }
+    *out = (uint64_t)v;
+    return true;
+}
+
+static wchar_t* dup_wstr(const wchar_t* s)
+{
+    if (s == NULL)
+    {
+        return NULL;
+    }
+    size_t n = wcslen(s) + 1;
+    wchar_t* r = (wchar_t*)malloc(n * sizeof(wchar_t));
+    if (r != NULL)
+    {
+        memcpy(r, s, n * sizeof(wchar_t));
+    }
+    return r;
+}
+
+static bool twd_parse_args(int argc, wchar_t** argv, TWD_CONFIG* cfg)
+{
+    cfg->timeout_seconds = TWD_DEFAULT_TIMEOUT_SECONDS;
+    cfg->dump_timeout_seconds = TWD_DEFAULT_DUMP_TIMEOUT_SECONDS;
+    cfg->max_dump_bytes = TWD_DEFAULT_MAX_DUMP_BYTES;
+    cfg->dump_tree = false;
+    cfg->full_dump = true;
+    cfg->dump_dir = NULL;
+    cfg->child_exe = NULL;
+    cfg->child_argc = 0;
+    cfg->child_argv = NULL;
+
+    int i = 1;
+    while (i < argc)
+    {
+        const wchar_t* a = argv[i];
+        if ((wcscmp(a, L"--") == 0))
+        {
+            i++;
+            break;
+        }
+        else if ((wcscmp(a, L"-h") == 0) || (wcscmp(a, L"--help") == 0))
+        {
+            print_usage();
+            return false;
+        }
+        else if (wcscmp(a, L"--timeout-seconds") == 0)
+        {
+            if (i + 1 >= argc) { TWD_LOG_ERROR(L"--timeout-seconds requires a value"); return false; }
+            if (!parse_uint32(argv[i + 1], &cfg->timeout_seconds)) { TWD_LOG_ERROR(L"invalid --timeout-seconds value: %ls", argv[i + 1]); return false; }
+            i += 2;
+        }
+        else if (wcscmp(a, L"--dump-timeout-seconds") == 0)
+        {
+            if (i + 1 >= argc) { TWD_LOG_ERROR(L"--dump-timeout-seconds requires a value"); return false; }
+            if (!parse_uint32(argv[i + 1], &cfg->dump_timeout_seconds)) { TWD_LOG_ERROR(L"invalid --dump-timeout-seconds value: %ls", argv[i + 1]); return false; }
+            i += 2;
+        }
+        else if (wcscmp(a, L"--max-dump-bytes") == 0)
+        {
+            if (i + 1 >= argc) { TWD_LOG_ERROR(L"--max-dump-bytes requires a value"); return false; }
+            if (!parse_uint64(argv[i + 1], &cfg->max_dump_bytes)) { TWD_LOG_ERROR(L"invalid --max-dump-bytes value: %ls", argv[i + 1]); return false; }
+            i += 2;
+        }
+        else if (wcscmp(a, L"--dump-dir") == 0)
+        {
+            if (i + 1 >= argc) { TWD_LOG_ERROR(L"--dump-dir requires a value"); return false; }
+            free(cfg->dump_dir);
+            cfg->dump_dir = dup_wstr(argv[i + 1]);
+            i += 2;
+        }
+        else if (wcscmp(a, L"--dump-tree") == 0)
+        {
+            cfg->dump_tree = true;
+            i++;
+        }
+        else if (wcscmp(a, L"--no-full-dump") == 0)
+        {
+            cfg->full_dump = false;
+            i++;
+        }
+        else
+        {
+            TWD_LOG_ERROR(L"unknown option: %ls (did you forget '--' before child exe?)", a);
+            return false;
+        }
+    }
+
+    if (i >= argc)
+    {
+        TWD_LOG_ERROR(L"missing child executable after '--'");
+        return false;
+    }
+
+    cfg->child_exe = dup_wstr(argv[i]);
+    cfg->child_argc = argc - i;
+    cfg->child_argv = &argv[i];
+    return true;
+}
+
+static void twd_apply_env_overrides(TWD_CONFIG* cfg)
+{
+    wchar_t buf[1024];
+    DWORD len;
+
+    // TEST_WATCHDOG_TIMEOUT_SECONDS
+    len = GetEnvironmentVariableW(L"TEST_WATCHDOG_TIMEOUT_SECONDS", buf, (DWORD)(sizeof(buf) / sizeof(buf[0])));
+    if ((len > 0) && (len < (sizeof(buf) / sizeof(buf[0]))))
+    {
+        uint32_t v = 0;
+        if (parse_uint32(buf, &v) && (v >= TWD_MIN_TIMEOUT_SECONDS) && (v <= TWD_MAX_TIMEOUT_SECONDS))
+        {
+            TWD_LOG_INFO(L"env override: timeout-seconds=%u (was %u)", v, cfg->timeout_seconds);
+            cfg->timeout_seconds = v;
+        }
+        else
+        {
+            TWD_LOG_WARNING(L"TEST_WATCHDOG_TIMEOUT_SECONDS='%ls' rejected (must be %u..%u)",
+                buf, TWD_MIN_TIMEOUT_SECONDS, TWD_MAX_TIMEOUT_SECONDS);
+        }
+    }
+
+    // TEST_WATCHDOG_DUMP_DIR
+    len = GetEnvironmentVariableW(L"TEST_WATCHDOG_DUMP_DIR", buf, (DWORD)(sizeof(buf) / sizeof(buf[0])));
+    if ((len > 0) && (len < (sizeof(buf) / sizeof(buf[0]))))
+    {
+        TWD_LOG_INFO(L"env override: dump-dir=%ls", buf);
+        free(cfg->dump_dir);
+        cfg->dump_dir = dup_wstr(buf);
+    }
+
+    // TEST_WATCHDOG_FULL_DUMP
+    len = GetEnvironmentVariableW(L"TEST_WATCHDOG_FULL_DUMP", buf, (DWORD)(sizeof(buf) / sizeof(buf[0])));
+    if ((len > 0) && (len < (sizeof(buf) / sizeof(buf[0]))))
+    {
+        if (wcscmp(buf, L"0") == 0)
+        {
+            TWD_LOG_INFO(L"env override: full-dump disabled (triage dump only)");
+            cfg->full_dump = false;
+        }
+    }
+}
+
+// Returns the base file name (no path, no extension) for log/dump naming.
+static void compute_basename_no_ext(const wchar_t* path, wchar_t* out, size_t out_chars)
+{
+    const wchar_t* slash = path;
+    for (const wchar_t* p = path; *p != L'\0'; p++)
+    {
+        if ((*p == L'\\') || (*p == L'/'))
+        {
+            slash = p + 1;
+        }
+    }
+    (void)wcsncpy_s(out, out_chars, slash, _TRUNCATE);
+    wchar_t* dot = wcsrchr(out, L'.');
+    if (dot != NULL)
+    {
+        *dot = L'\0';
+    }
+}
+
+static void compute_dump_path(const wchar_t* dump_dir, const wchar_t* child_exe, DWORD pid, wchar_t* out, size_t out_chars)
+{
+    wchar_t base[260];
+    compute_basename_no_ext(child_exe, base, sizeof(base) / sizeof(base[0]));
+
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+    (void)swprintf_s(out, out_chars, L"%ls\\%ls_%lu_%04u%02u%02u_%02u%02u%02u.dmp",
+        dump_dir, base, (unsigned long)pid,
+        st.wYear, st.wMonth, st.wDay,
+        st.wHour, st.wMinute, st.wSecond);
+}
+
+static bool ensure_directory(const wchar_t* path)
+{
+    DWORD attrs = GetFileAttributesW(path);
+    if ((attrs != INVALID_FILE_ATTRIBUTES) && ((attrs & FILE_ATTRIBUTE_DIRECTORY) != 0))
+    {
+        return true;
+    }
+    if (CreateDirectoryW(path, NULL))
+    {
+        return true;
+    }
+    DWORD err = GetLastError();
+    if (err == ERROR_ALREADY_EXISTS)
+    {
+        return true;
+    }
+    TWD_LOG_ERROR(L"failed to create dump directory '%ls' (GetLastError=%lu)", path, (unsigned long)err);
+    return false;
+}
+
+static uint64_t get_dir_size_bytes(const wchar_t* dir)
+{
+    wchar_t pattern[MAX_PATH * 2];
+    (void)swprintf_s(pattern, sizeof(pattern) / sizeof(pattern[0]), L"%ls\\*", dir);
+    WIN32_FIND_DATAW fd;
+    HANDLE h = FindFirstFileW(pattern, &fd);
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        return 0;
+    }
+    uint64_t total = 0;
+    do
+    {
+        if ((fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0)
+        {
+            uint64_t sz = ((uint64_t)fd.nFileSizeHigh << 32) | (uint64_t)fd.nFileSizeLow;
+            total += sz;
+        }
+    } while (FindNextFileW(h, &fd));
+    FindClose(h);
+    return total;
+}
+
+// Build a Win32 command line from argv. Each argument is quoted per Win32
+// CommandLineToArgvW rules. The caller takes ownership of the returned
+// allocation (free with free()).
+static wchar_t* build_command_line(int argc, wchar_t** argv)
+{
+    size_t total = 0;
+    for (int i = 0; i < argc; i++)
+    {
+        // Worst case: every char becomes "\\\\\"" + 2 quotes + 1 space => 5x + 3
+        total += wcslen(argv[i]) * 5 + 3;
+    }
+    total += 1; // null terminator
+    wchar_t* buf = (wchar_t*)malloc(total * sizeof(wchar_t));
+    if (buf == NULL)
+    {
+        return NULL;
+    }
+    size_t pos = 0;
+    for (int i = 0; i < argc; i++)
+    {
+        if (i > 0)
+        {
+            buf[pos++] = L' ';
+        }
+        const wchar_t* a = argv[i];
+        bool needs_quote = (a[0] == L'\0') || (wcspbrk(a, L" \t\v\n\"") != NULL);
+        if (!needs_quote)
+        {
+            size_t n = wcslen(a);
+            memcpy(buf + pos, a, n * sizeof(wchar_t));
+            pos += n;
+        }
+        else
+        {
+            buf[pos++] = L'"';
+            size_t backslashes = 0;
+            for (const wchar_t* p = a; *p != L'\0'; p++)
+            {
+                if (*p == L'\\')
+                {
+                    backslashes++;
+                }
+                else if (*p == L'"')
+                {
+                    // Double the run of backslashes, then escape the quote.
+                    for (size_t k = 0; k < backslashes; k++) { buf[pos++] = L'\\'; }
+                    buf[pos++] = L'\\';
+                    buf[pos++] = L'"';
+                    backslashes = 0;
+                }
+                else
+                {
+                    for (size_t k = 0; k < backslashes; k++) { buf[pos++] = L'\\'; }
+                    buf[pos++] = *p;
+                    backslashes = 0;
+                }
+            }
+            // Double trailing backslashes before the closing quote.
+            for (size_t k = 0; k < backslashes * 2; k++) { buf[pos++] = L'\\'; }
+            buf[pos++] = L'"';
+        }
+    }
+    buf[pos] = L'\0';
+    return buf;
+}
+
+// Returns TRUE on Ctrl-C handling success (so the system doesn't run the
+// next handler). Sets g_cancelled and terminates the job to kill the child
+// tree.
+static BOOL WINAPI console_ctrl_handler(DWORD ctrl_type)
+{
+    switch (ctrl_type)
+    {
+    case CTRL_C_EVENT:
+    case CTRL_BREAK_EVENT:
+    case CTRL_CLOSE_EVENT:
+    case CTRL_LOGOFF_EVENT:
+    case CTRL_SHUTDOWN_EVENT:
+        InterlockedExchange(&g_cancelled, 1);
+        if (g_job_handle != NULL)
+        {
+            TWD_LOG_WARNING(L"received console control event %lu; terminating job",
+                (unsigned long)ctrl_type);
+            (void)TerminateJobObject(g_job_handle, (UINT)TWD_EXIT_CANCELLED);
+        }
+        return TRUE;
+    default:
+        return FALSE;
+    }
+}
+
+// --dump-helper <pid> <dump_path> <flags_hex>
+// Runs MiniDumpWriteDump on the target pid into dump_path. Exits 0 on
+// success, nonzero on failure. Designed to be killable: if dump itself
+// hangs, the parent watchdog can TerminateProcess this helper.
+static int dump_helper_mode(int argc, wchar_t** argv)
+{
+    if (argc < 5)
+    {
+        TWD_LOG_ERROR(L"--dump-helper requires <pid> <path> <flags_hex>");
+        return TWD_EXIT_USAGE;
+    }
+    uint32_t pid32 = 0;
+    if (!parse_uint32(argv[2], &pid32))
+    {
+        TWD_LOG_ERROR(L"--dump-helper: bad pid '%ls'", argv[2]);
+        return TWD_EXIT_USAGE;
+    }
+    const wchar_t* path = argv[3];
+    wchar_t* end = NULL;
+    unsigned long flags = wcstoul(argv[4], &end, 16);
+    if ((end == NULL) || (*end != L'\0'))
+    {
+        TWD_LOG_ERROR(L"--dump-helper: bad flags '%ls'", argv[4]);
+        return TWD_EXIT_USAGE;
+    }
+
+    HANDLE proc = OpenProcess(
+        PROCESS_QUERY_INFORMATION | PROCESS_VM_READ | PROCESS_DUP_HANDLE,
+        FALSE,
+        (DWORD)pid32);
+    if (proc == NULL)
+    {
+        TWD_LOG_ERROR(L"--dump-helper: OpenProcess(%u) failed (GetLastError=%lu)",
+            (unsigned)pid32, (unsigned long)GetLastError());
+        return 1;
+    }
+
+    HANDLE file = CreateFileW(path, GENERIC_WRITE, 0, NULL,
+        CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (file == INVALID_HANDLE_VALUE)
+    {
+        TWD_LOG_ERROR(L"--dump-helper: CreateFileW('%ls') failed (GetLastError=%lu)",
+            path, (unsigned long)GetLastError());
+        CloseHandle(proc);
+        return 1;
+    }
+
+    BOOL ok = MiniDumpWriteDump(proc, (DWORD)pid32, file,
+        (MINIDUMP_TYPE)flags, NULL, NULL, NULL);
+    DWORD dump_err = ok ? 0 : GetLastError();
+    CloseHandle(file);
+    CloseHandle(proc);
+
+    if (!ok)
+    {
+        TWD_LOG_ERROR(L"--dump-helper: MiniDumpWriteDump failed (GetLastError=0x%08lx)",
+            (unsigned long)dump_err);
+        (void)DeleteFileW(path);
+        return 1;
+    }
+
+    LARGE_INTEGER fsize;
+    fsize.QuadPart = 0;
+    HANDLE fh = CreateFileW(path, GENERIC_READ, FILE_SHARE_READ, NULL,
+        OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (fh != INVALID_HANDLE_VALUE)
+    {
+        (void)GetFileSizeEx(fh, &fsize);
+        CloseHandle(fh);
+    }
+    TWD_LOG_INFO(L"--dump-helper: wrote dump '%ls' (%lld bytes)", path,
+        (long long)fsize.QuadPart);
+    return 0;
+}
+
+// Spawn the helper for one pid; wait up to dump_timeout_seconds. Returns
+// true on success (dump file should now exist). On helper timeout,
+// terminates the helper and returns false.
+static bool capture_dump_for_pid(const wchar_t* self_exe, DWORD pid,
+    const wchar_t* dump_path, MINIDUMP_TYPE flags, uint32_t dump_timeout_seconds)
+{
+    wchar_t flags_hex[20];
+    (void)swprintf_s(flags_hex, sizeof(flags_hex) / sizeof(flags_hex[0]),
+        L"%lx", (unsigned long)flags);
+
+    wchar_t pid_buf[16];
+    (void)swprintf_s(pid_buf, sizeof(pid_buf) / sizeof(pid_buf[0]),
+        L"%lu", (unsigned long)pid);
+
+    wchar_t* helper_argv[5];
+    helper_argv[0] = (wchar_t*)self_exe;
+    helper_argv[1] = L"--dump-helper";
+    helper_argv[2] = pid_buf;
+    helper_argv[3] = (wchar_t*)dump_path;
+    helper_argv[4] = flags_hex;
+
+    wchar_t* cmdline = build_command_line(5, helper_argv);
+    if (cmdline == NULL)
+    {
+        TWD_LOG_ERROR(L"out of memory building helper command line");
+        return false;
+    }
+
+    STARTUPINFOW si;
+    memset(&si, 0, sizeof(si));
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput  = GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+    si.hStdError  = GetStdHandle(STD_ERROR_HANDLE);
+
+    PROCESS_INFORMATION pi;
+    memset(&pi, 0, sizeof(pi));
+
+    BOOL ok = CreateProcessW(
+        self_exe, cmdline, NULL, NULL, TRUE,
+        0, NULL, NULL, &si, &pi);
+    free(cmdline);
+
+    if (!ok)
+    {
+        TWD_LOG_ERROR(L"failed to spawn dump helper for pid %lu (GetLastError=%lu)",
+            (unsigned long)pid, (unsigned long)GetLastError());
+        return false;
+    }
+
+    DWORD wait = WaitForSingleObject(pi.hProcess, dump_timeout_seconds * 1000u);
+    bool success = false;
+    if (wait == WAIT_OBJECT_0)
+    {
+        DWORD exit_code = 1;
+        (void)GetExitCodeProcess(pi.hProcess, &exit_code);
+        success = (exit_code == 0);
+    }
+    else if (wait == WAIT_TIMEOUT)
+    {
+        TWD_LOG_ERROR(L"dump helper for pid %lu exceeded %u seconds; terminating it",
+            (unsigned long)pid, dump_timeout_seconds);
+        (void)TerminateProcess(pi.hProcess, 1);
+        (void)WaitForSingleObject(pi.hProcess, 5000);
+    }
+    else
+    {
+        TWD_LOG_ERROR(L"WaitForSingleObject on dump helper returned %lu (GetLastError=%lu)",
+            (unsigned long)wait, (unsigned long)GetLastError());
+    }
+
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    return success;
+}
+
+// Returns a malloc'd array of pids belonging to the job. *out_count gets the
+// number of pids. Caller must free *out_pids.
+static bool enumerate_job_pids(HANDLE job, DWORD** out_pids, size_t* out_count)
+{
+    *out_pids = NULL;
+    *out_count = 0;
+
+    DWORD capacity = 32;
+    for (;;)
+    {
+        size_t bytes = sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST) + (size_t)(capacity - 1) * sizeof(ULONG_PTR);
+        JOBOBJECT_BASIC_PROCESS_ID_LIST* info = (JOBOBJECT_BASIC_PROCESS_ID_LIST*)malloc(bytes);
+        if (info == NULL)
+        {
+            return false;
+        }
+        memset(info, 0, bytes);
+        DWORD ret = 0;
+        BOOL ok = QueryInformationJobObject(job, JobObjectBasicProcessIdList,
+            info, (DWORD)bytes, &ret);
+        if (!ok)
+        {
+            DWORD err = GetLastError();
+            free(info);
+            if (err == ERROR_MORE_DATA)
+            {
+                capacity *= 2;
+                continue;
+            }
+            TWD_LOG_WARNING(L"QueryInformationJobObject failed (GetLastError=%lu)",
+                (unsigned long)err);
+            return false;
+        }
+        DWORD count = info->NumberOfProcessIdsInList;
+        DWORD* pids = NULL;
+        if (count > 0)
+        {
+            pids = (DWORD*)malloc(count * sizeof(DWORD));
+            if (pids == NULL)
+            {
+                free(info);
+                return false;
+            }
+            for (DWORD i = 0; i < count; i++)
+            {
+                pids[i] = (DWORD)info->ProcessIdList[i];
+            }
+        }
+        free(info);
+        *out_pids = pids;
+        *out_count = count;
+        return true;
+    }
+}
+
+static int run_watchdog(TWD_CONFIG* cfg, const wchar_t* self_exe)
+{
+    if (cfg->dump_dir == NULL)
+    {
+        TWD_LOG_ERROR(L"--dump-dir is required");
+        return TWD_EXIT_USAGE;
+    }
+    if ((cfg->timeout_seconds < TWD_MIN_TIMEOUT_SECONDS) ||
+        (cfg->timeout_seconds > TWD_MAX_TIMEOUT_SECONDS))
+    {
+        TWD_LOG_WARNING(L"timeout %u out of range (%u..%u); clamping to default %u",
+            cfg->timeout_seconds, TWD_MIN_TIMEOUT_SECONDS, TWD_MAX_TIMEOUT_SECONDS,
+            TWD_DEFAULT_TIMEOUT_SECONDS);
+        cfg->timeout_seconds = TWD_DEFAULT_TIMEOUT_SECONDS;
+    }
+    if (!ensure_directory(cfg->dump_dir))
+    {
+        return TWD_EXIT_SPAWN_FAILED;
+    }
+
+    TWD_LOG_INFO(L"effective config: child='%ls' timeout=%us dump_timeout=%us dump_dir='%ls' full_dump=%s dump_tree=%s",
+        cfg->child_exe, cfg->timeout_seconds, cfg->dump_timeout_seconds,
+        cfg->dump_dir,
+        cfg->full_dump ? L"yes" : L"no",
+        cfg->dump_tree ? L"yes" : L"no");
+
+    // Create the job object. Set kill-on-close so an accidental wrapper
+    // crash kills the child tree. Set breakaway-OK so we can be safely
+    // nested inside ctest's / agent's job if any.
+    HANDLE job = CreateJobObjectW(NULL, NULL);
+    if (job == NULL)
+    {
+        TWD_LOG_ERROR(L"CreateJobObject failed (GetLastError=%lu)",
+            (unsigned long)GetLastError());
+        return TWD_EXIT_SPAWN_FAILED;
+    }
+    g_job_handle = job;
+
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli;
+    memset(&jeli, 0, sizeof(jeli));
+    jeli.BasicLimitInformation.LimitFlags =
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE |
+        JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+    if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation,
+        &jeli, sizeof(jeli)))
+    {
+        TWD_LOG_WARNING(L"SetInformationJobObject failed (GetLastError=%lu); continuing",
+            (unsigned long)GetLastError());
+    }
+
+    if (!SetConsoleCtrlHandler(console_ctrl_handler, TRUE))
+    {
+        TWD_LOG_WARNING(L"SetConsoleCtrlHandler failed (GetLastError=%lu); continuing",
+            (unsigned long)GetLastError());
+    }
+
+    // Build the child command line (argv[0] = child exe path).
+    wchar_t* cmdline = build_command_line(cfg->child_argc, cfg->child_argv);
+    if (cmdline == NULL)
+    {
+        TWD_LOG_ERROR(L"out of memory building child command line");
+        CloseHandle(job);
+        return TWD_EXIT_SPAWN_FAILED;
+    }
+
+    STARTUPINFOW si;
+    memset(&si, 0, sizeof(si));
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES;
+    si.hStdInput  = GetStdHandle(STD_INPUT_HANDLE);
+    si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+    si.hStdError  = GetStdHandle(STD_ERROR_HANDLE);
+
+    PROCESS_INFORMATION pi;
+    memset(&pi, 0, sizeof(pi));
+
+    // CREATE_SUSPENDED so we can assign to the job *before* the child runs
+    // and can spawn any descendants. Inherit handles for stdio forwarding
+    // (ctest -V / --output-on-failure depends on this).
+    //
+    // Pass NULL for lpApplicationName so Windows applies its standard
+    // command-line resolution rules (PATH search, .exe extension, etc.).
+    // ctest passes the absolute path via $<TARGET_FILE:...> so this is a
+    // no-op in CI but makes local invocations like 'cmd.exe' work too.
+    BOOL ok = CreateProcessW(
+        NULL, cmdline, NULL, NULL, TRUE,
+        CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT,
+        NULL, NULL, &si, &pi);
+    free(cmdline);
+
+    if (!ok)
+    {
+        DWORD err = GetLastError();
+        TWD_LOG_ERROR(L"CreateProcessW('%ls') failed (GetLastError=%lu)",
+            cfg->child_exe, (unsigned long)err);
+        CloseHandle(job);
+        return TWD_EXIT_SPAWN_FAILED;
+    }
+
+    bool in_job = false;
+    if (AssignProcessToJobObject(job, pi.hProcess))
+    {
+        in_job = true;
+    }
+    else
+    {
+        TWD_LOG_WARNING(L"AssignProcessToJobObject failed (GetLastError=%lu); falling back to immediate-child only (no tree kill)",
+            (unsigned long)GetLastError());
+    }
+
+    if (ResumeThread(pi.hThread) == (DWORD)-1)
+    {
+        TWD_LOG_ERROR(L"ResumeThread failed (GetLastError=%lu); terminating",
+            (unsigned long)GetLastError());
+        (void)TerminateProcess(pi.hProcess, 1);
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+        CloseHandle(job);
+        return TWD_EXIT_SPAWN_FAILED;
+    }
+
+    TWD_LOG_INFO(L"spawned child pid=%lu in_job=%s",
+        (unsigned long)pi.dwProcessId, in_job ? L"yes" : L"no");
+
+    DWORD wait = WaitForSingleObject(pi.hProcess, cfg->timeout_seconds * 1000u);
+    int rc = 0;
+    if (wait == WAIT_OBJECT_0)
+    {
+        DWORD child_exit = 0;
+        (void)GetExitCodeProcess(pi.hProcess, &child_exit);
+        rc = (int)child_exit;
+        TWD_LOG_INFO(L"child exited normally with code %d", rc);
+    }
+    else if (wait == WAIT_TIMEOUT)
+    {
+        TWD_LOG_ERROR(L"TIMEOUT after %us for '%ls' (pid=%lu)",
+            cfg->timeout_seconds, cfg->child_exe, (unsigned long)pi.dwProcessId);
+
+        MINIDUMP_TYPE flags = cfg->full_dump ? TWD_FULL_DUMP_FLAGS : TWD_TRIAGE_DUMP_FLAGS;
+
+        // Budget check before any dump.
+        uint64_t dir_size = get_dir_size_bytes(cfg->dump_dir);
+        if (dir_size >= cfg->max_dump_bytes)
+        {
+            TWD_LOG_WARNING(L"dump directory already at %llu bytes (budget %llu); skipping dump",
+                (unsigned long long)dir_size, (unsigned long long)cfg->max_dump_bytes);
+        }
+        else
+        {
+            wchar_t dump_path[MAX_PATH * 2];
+            compute_dump_path(cfg->dump_dir, cfg->child_exe, pi.dwProcessId,
+                dump_path, sizeof(dump_path) / sizeof(dump_path[0]));
+            TWD_LOG_ERROR(L"capturing dump to '%ls' (flags=0x%lx, helper timeout=%us)",
+                dump_path, (unsigned long)flags, cfg->dump_timeout_seconds);
+            bool dumped = capture_dump_for_pid(self_exe, pi.dwProcessId, dump_path,
+                flags, cfg->dump_timeout_seconds);
+            if (!dumped)
+            {
+                TWD_LOG_ERROR(L"failed to capture dump for main child pid %lu",
+                    (unsigned long)pi.dwProcessId);
+            }
+
+            // Optionally dump descendants.
+            if (cfg->dump_tree && in_job)
+            {
+                DWORD* pids = NULL;
+                size_t pid_count = 0;
+                if (enumerate_job_pids(job, &pids, &pid_count))
+                {
+                    for (size_t k = 0; k < pid_count; k++)
+                    {
+                        if (pids[k] == pi.dwProcessId)
+                        {
+                            continue;
+                        }
+                        if (get_dir_size_bytes(cfg->dump_dir) >= cfg->max_dump_bytes)
+                        {
+                            TWD_LOG_WARNING(L"budget reached during tree dump; stopping after %zu of %zu descendants",
+                                k, pid_count);
+                            break;
+                        }
+                        wchar_t child_dump_path[MAX_PATH * 2];
+                        (void)swprintf_s(child_dump_path, sizeof(child_dump_path) / sizeof(child_dump_path[0]),
+                            L"%ls\\descendant_%lu_of_%lu.dmp",
+                            cfg->dump_dir, (unsigned long)pids[k], (unsigned long)pi.dwProcessId);
+                        TWD_LOG_ERROR(L"capturing descendant dump pid=%lu to '%ls'",
+                            (unsigned long)pids[k], child_dump_path);
+                        (void)capture_dump_for_pid(self_exe, pids[k], child_dump_path,
+                            flags, cfg->dump_timeout_seconds);
+                    }
+                    free(pids);
+                }
+            }
+        }
+
+        // Tree kill via job (or direct if not in job).
+        if (in_job)
+        {
+            TWD_LOG_ERROR(L"terminating job (process tree)");
+            (void)TerminateJobObject(job, (UINT)TWD_EXIT_TIMEOUT);
+        }
+        else
+        {
+            TWD_LOG_ERROR(L"terminating child only (not in job)");
+            (void)TerminateProcess(pi.hProcess, (UINT)TWD_EXIT_TIMEOUT);
+        }
+        (void)WaitForSingleObject(pi.hProcess, 10000);
+        rc = TWD_EXIT_TIMEOUT;
+    }
+    else
+    {
+        DWORD err = GetLastError();
+        TWD_LOG_ERROR(L"WaitForSingleObject returned %lu (GetLastError=%lu); terminating child",
+            (unsigned long)wait, (unsigned long)err);
+        (void)TerminateJobObject(job, TWD_EXIT_SPAWN_FAILED);
+        rc = TWD_EXIT_SPAWN_FAILED;
+    }
+
+    if (InterlockedCompareExchange(&g_cancelled, 0, 0) != 0)
+    {
+        TWD_LOG_WARNING(L"watchdog was cancelled mid-run; reporting cancellation exit code");
+        rc = TWD_EXIT_CANCELLED;
+    }
+
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    g_job_handle = NULL;
+    CloseHandle(job);
+    return rc;
+}
+
+int wmain(int argc, wchar_t** argv)
+{
+    // Unbuffer stderr so banners survive a hard kill.
+    setvbuf(stderr, NULL, _IONBF, 0);
+
+    if ((argc >= 2) && (wcscmp(argv[1], L"--dump-helper") == 0))
+    {
+        return dump_helper_mode(argc, argv);
+    }
+
+    wchar_t self_exe[MAX_PATH * 2];
+    DWORD self_len = GetModuleFileNameW(NULL, self_exe,
+        (DWORD)(sizeof(self_exe) / sizeof(self_exe[0])));
+    if ((self_len == 0) || (self_len >= sizeof(self_exe) / sizeof(self_exe[0])))
+    {
+        TWD_LOG_ERROR(L"GetModuleFileNameW failed (GetLastError=%lu)",
+            (unsigned long)GetLastError());
+        return TWD_EXIT_SPAWN_FAILED;
+    }
+
+    TWD_CONFIG cfg;
+    if (!twd_parse_args(argc, argv, &cfg))
+    {
+        free(cfg.dump_dir);
+        free(cfg.child_exe);
+        return TWD_EXIT_USAGE;
+    }
+    twd_apply_env_overrides(&cfg);
+
+    int rc = run_watchdog(&cfg, self_exe);
+
+    free(cfg.dump_dir);
+    free(cfg.child_exe);
+    return rc;
+}


### PR DESCRIPTION
**Draft** - test_watchdog: a per-test timeout launcher with full-memory minidump capture, plus a backward-compatible CMake hook to wire it in.

This PR consolidates two commits:
1. `[MrBot] Add backward-compatible TEST_LAUNCHER_COMMAND hook to build_test_folder` (the CMake-side wiring that lets a consumer plug in a launcher)
2. `[MrBot] Add test_watchdog launcher tool + self-tests` (the launcher binary itself, plus 6 self-tests)

## Why

Driven by an EBS hang ([msazure One task 37167901](https://msazure.visualstudio.com/One/_workitems/edit/37167901)) where `sp_index_sync_int` printed `10 tests ran, 0 failed, 10 succeeded.` and then sat silent for **24 minutes** before CTest's default 1500s timeout fired. CTest's only response to a timeout is `TerminateProcess` — no dump, no stack, no diagnostic. That's the gap this fills.

The watchdog wraps the test exe externally and, on hang, captures a full-memory minidump *before* killing the process tree. The dump is published as a pipeline artifact (consumer-side YAML, not in this PR) so the failure is actionable.

## What's in this PR

### `tools/test_watchdog/test_watchdog.c`
Native Win32 wrapper. Self-contained: depends only on `kernel32`, `dbghelp`, `psapi` — zero project libs (so it works as a launcher for the very tests that would otherwise transitively link against the project libs).

Notable design choices:
- `CREATE_SUSPENDED` + `AssignProcessToJobObject` + `ResumeThread` to close the spawn-before-job race.
- `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` + `BREAKAWAY_OK` for safe nesting inside ctest's / agent's job.
- **Dump via helper-process pattern**: re-invokes itself as `test_watchdog --dump-helper <pid> <path> <flags>`. Avoids the "dumping a loader-lock-stuck target can also hang `MiniDumpWriteDump`" trap, which would be a real risk for the exact `sp_index_sync_int` failure pattern.
- `--max-dump-bytes` budget so 16 simultaneous ASAN hangs cannot fill the disk.
- `SetConsoleCtrlHandler` for clean Ctrl-C / pipeline cancellation.
- Env-var overrides (`TEST_WATCHDOG_TIMEOUT_SECONDS`, `TEST_WATCHDOG_DUMP_DIR`, `TEST_WATCHDOG_FULL_DUMP`) so per-test config doesn't require recompile.
- Exit codes: child's code on normal completion, 124 on timeout, 130 on cancellation, 2 on usage, 125 on spawn failure.

### `tools/test_watchdog/CMakeLists.txt`
Builds the `test_watchdog` target. Gated on `WIN32` (dbghelp is Windows-only). Disables VLD (the VLD banner would pollute ctest -V output and the tool doesn't need leak detection).

### `test_projects/test_watchdog_int/{CMakeLists.txt, test_watchdog_int.c}`
Plain Win32 self-tests (deliberately NOT a c-testrunnerswitcher framework suite — the watchdog has no project deps and we want the self-tests to match that constraint). Six cases:
1. `successful_child_returns_zero`
2. `propagates_nonzero_child_exit_code`
3. `times_out_and_captures_minidump` (verifies the MDMP magic in the captured file)
4. `env_timeout_override_takes_precedence`
5. `rejects_missing_dump_dir`
6. `dump_tree_captures_descendant_dumps`

The self-tests resolve the watchdog binary at runtime via `GetModuleFileNameW` + path-join (rather than a build-time `-DTEST_WATCHDOG_EXE_PATH=...` macro), because in CI the build agent and test agent generally have different `_work` directory layouts — a compile-time absolute path would be wrong on the test agent. The CMakeLists places the self-test exe in the same directory as `test_watchdog.exe` so the runtime resolution works.

### `build_functions/CMakeLists.txt`
Two additions on top of the existing `TEST_LAUNCHER_COMMAND` hook:
- `set_test_watchdog_timeout(test_name seconds)`: per-test override helper. Sets both the `TEST_WATCHDOG_TIMEOUT_SECONDS` env var (read by the launcher at run time) AND the matching CTest `TIMEOUT` property = `seconds + dump_timeout + 60s` slack, so CTest doesn't preempt the launcher mid-dump.
- The helper skips silently in non-exe passes of `build_test_folder` (with `use_cppunittest=ON` each test dir is processed twice — exe + dll — and only the exe pass calls `add_test`; the dll pass's directory scope wouldn't see the test).

### Root `CMakeLists.txt`
Adds `use_test_watchdog` option (default ON on Windows, OFF elsewhere) and `add_subdirectory(tools/test_watchdog)` gated on that option + `WIN32` — so consuming projects get the launcher binary automatically when they consume c-testrunnerswitcher.

### `test_projects/CMakeLists.txt`
Adds the self-tests subtree, gated on `run_int_tests` + `use_test_watchdog` + `WIN32`, with `TEST_LAUNCHER_DISABLED` set so the self-tests aren't wrapped by the very tool they're testing.

## Backward compatibility

Both commits are purely additive. Existing callers that don't define `TEST_LAUNCHER_COMMAND_INT` and don't set `use_test_watchdog` continue to behave exactly as before. `build_exe` falls back to its original single-line `add_test` when no launcher is configured.

## Validated

- **c-testrunnerswitcher standalone**: builds clean. 6/6 self-tests pass in ~8s on a dev box.
- **Consumed by Azure-MessagingStore (EBS)**: wrapped int tests register correctly through `build_test_folder`; per-test override via `set_test_watchdog_timeout` produces the right CTest TIMEOUT property and env var.
- **End-to-end on real CI hardware**: prior dry-run consumer-side build (build 164664698) showed the watchdog firing at 30s on a synthetic 5-min `Sleep`, capturing a 120 MB minidump, publishing it as a pipeline artifact. The dump opens cleanly in `cdb` with the main thread parked in `ntdll!ZwDelayExecution+0x14` — exactly the hang point.

## Notes for reviewers

- The watchdog deliberately does NOT use any project libs (no c-logging, no c-pal, no umock-c). This keeps it lean and lets it wrap test exes that DO link those libs without bootstrap concerns.
- The dump artifact upload path (Watson, pipeline artifact) is consumer-side YAML, not in this PR.
- Linux path is intentionally a no-op in v1 — the underlying motivation came from a Windows-only test pool. Linux equivalent would use `gcore` + `SIGABRT`; can be added later under a new `UNIX` branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
