### PR TITLE
[MrBot] Add guidance: prefer enum type in ASSERT_ARE_EQUAL

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,20 +119,6 @@ TEST_DEFINE_ENUM_TYPE(MY_ENUM, VALUE1, VALUE2, VALUE3)
 TEST_DEFINE_ENUM_TYPE_WITHOUT_INVALID(MY_ENUM, VALUE1, VALUE2)
 ```
 
-#### Prefer the actual enum type when asserting enum values
-When asserting a value whose declared type is an enum, always pass the enum type as the first argument to
-`ASSERT_ARE_EQUAL`. Do not cast to `int` just to make the assert compile:
-
-```c
-// BAD - loses type information, no symbolic name on failure
-ASSERT_ARE_EQUAL(int, (int)MY_RESULT_OK, (int)result);
-
-// GOOD - prints the enum value names on failure
-ASSERT_ARE_EQUAL(MY_RESULT, MY_RESULT_OK, result);
-```
-
-The enum-typed assert prints the symbolic name of both expected and actual values (e.g. `MY_RESULT_TIMED_OUT` instead of `1`), which is far more useful when diagnosing failures from CI logs.
-
 ### Test Execution (ctest mode only)
 ```c
 // Basic execution
@@ -271,6 +257,10 @@ END_TEST_SUITE(component_tests)
 
 // Leverage optional message formatting
 ASSERT_ARE_EQUAL(int, expected, actual, "Operation failed with code %d", error_code);
+
+// Pass the enum type to ASSERT_ARE_EQUAL so failures print symbolic names
+// (e.g. MY_RESULT_TIMED_OUT instead of 1) rather than raw integers
+ASSERT_ARE_EQUAL(MY_RESULT, MY_RESULT_OK, result);
 ```
 
 ### ❌ Anti-Patterns to Avoid
@@ -285,6 +275,10 @@ ASSERT_ARE_EQUAL(int, expected, actual, "Operation failed with code %d", error_c
 
 // Don't mix framework calls in hybrid mode
 RUN_TEST_SUITE(MySuite);  // Wrong in CppUnitTest - this is ctest-only
+
+// Don't cast enum values to int just to make ASSERT_ARE_EQUAL compile -
+// this loses type information and prints raw integers on failure
+ASSERT_ARE_EQUAL(int, (int)MY_RESULT_OK, (int)result);  // Wrong - use the enum type instead
 ```
 
 The test runner switcher's primary value is enabling identical test code to work across different execution environments while maintaining the specific advantages of each framework.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,11 +131,6 @@ ASSERT_ARE_EQUAL(int, (int)MY_RESULT_OK, (int)result);
 ASSERT_ARE_EQUAL(MY_RESULT, MY_RESULT_OK, result);
 ```
 
-Register the enum with the test framework using `TEST_DEFINE_ENUM_TYPE`:
-```c
-TEST_DEFINE_ENUM_TYPE(MY_RESULT, MY_RESULT_VALUES);
-```
-
 The enum-typed assert prints the symbolic name of both expected and actual values (e.g. `MY_RESULT_TIMED_OUT` instead of `1`), which is far more useful when diagnosing failures from CI logs.
 
 ### Test Execution (ctest mode only)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,6 +119,25 @@ TEST_DEFINE_ENUM_TYPE(MY_ENUM, VALUE1, VALUE2, VALUE3)
 TEST_DEFINE_ENUM_TYPE_WITHOUT_INVALID(MY_ENUM, VALUE1, VALUE2)
 ```
 
+#### Prefer the actual enum type when asserting enum values
+When asserting a value whose declared type is an enum, always pass the enum type as the first argument to
+`ASSERT_ARE_EQUAL`. Do not cast to `int` just to make the assert compile:
+
+```c
+// BAD - loses type information, no symbolic name on failure
+ASSERT_ARE_EQUAL(int, (int)MY_RESULT_OK, (int)result);
+
+// GOOD - prints the enum value names on failure
+ASSERT_ARE_EQUAL(MY_RESULT, MY_RESULT_OK, result);
+```
+
+Register the enum with the test framework using `TEST_DEFINE_ENUM_TYPE`:
+```c
+TEST_DEFINE_ENUM_TYPE(MY_RESULT, MY_RESULT_VALUES);
+```
+
+The enum-typed assert prints the symbolic name of both expected and actual values (e.g. `MY_RESULT_TIMED_OUT` instead of `1`), which is far more useful when diagnosing failures from CI logs.
+
 ### Test Execution (ctest mode only)
 ```c
 // Basic execution

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -258,8 +258,10 @@ END_TEST_SUITE(component_tests)
 // Leverage optional message formatting
 ASSERT_ARE_EQUAL(int, expected, actual, "Operation failed with code %d", error_code);
 
-// Pass the enum type to ASSERT_ARE_EQUAL so failures print symbolic names
-// (e.g. MY_RESULT_TIMED_OUT instead of 1) rather than raw integers
+// Register the enum with TEST_DEFINE_ENUM_TYPE and pass the enum type to
+// ASSERT_ARE_EQUAL so failures print symbolic names (e.g. MY_RESULT_TIMED_OUT
+// instead of 1) rather than raw integers
+TEST_DEFINE_ENUM_TYPE(MY_RESULT, MY_RESULT_VALUES);
 ASSERT_ARE_EQUAL(MY_RESULT, MY_RESULT_OK, result);
 ```
 
@@ -276,9 +278,11 @@ ASSERT_ARE_EQUAL(MY_RESULT, MY_RESULT_OK, result);
 // Don't mix framework calls in hybrid mode
 RUN_TEST_SUITE(MySuite);  // Wrong in CppUnitTest - this is ctest-only
 
-// Don't cast enum values to int just to make ASSERT_ARE_EQUAL compile -
-// this loses type information and prints raw integers on failure
-ASSERT_ARE_EQUAL(int, (int)MY_RESULT_OK, (int)result);  // Wrong - use the enum type instead
+// When ASSERT_ARE_EQUAL on an enum doesn't compile, don't fall back to
+// casting to int - that hides the real fix, which is to register the enum
+// with TEST_DEFINE_ENUM_TYPE and assert with the enum type. Casting to int
+// loses type information and prints raw integers on failure
+ASSERT_ARE_EQUAL(int, (int)MY_RESULT_OK, (int)result);  // Wrong - register the enum and assert with its type
 ```
 
 The test runner switcher's primary value is enabling identical test code to work across different execution environments while maintaining the specific advantages of each framework.


### PR DESCRIPTION
Adds guidance to `.github/copilot-instructions.md` instructing contributors to pass the actual enum type to `ASSERT_ARE_EQUAL` rather than casting to `int`, so failure messages print symbolic enum names instead of raw integers.

The guidance is split across the existing Recommended Patterns (positive example) and Anti-Patterns (negative example) blocks to match the style of that section.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>