### PR TITLE
Bump ARM64 gate pool to Dpldsv6-v29

### DIFF
--- a/build/devops_gated.yml
+++ b/build/devops_gated.yml
@@ -8,7 +8,7 @@ parameters:
   - name: pool_name_windows_arm64
     displayName: 'Windows ARM64 Pool'
     type: string
-    default: 'Azure-MessagingStore-Win-ARM64-Dpldsv6-v28'
+    default: 'Azure-MessagingStore-Win-ARM64-Dpldsv6-v29'
   - name: pool_name_linux
     displayName: 'Linux Pool'
     type: string


### PR DESCRIPTION
Bump the ARM64 gate pool default from `Azure-MessagingStore-Win-ARM64-Dpldsv6-v28` to `v29`.

The v29 ARM64 hosted pool is the current provisioned pool (v28 is being decommissioned to reclaim core quota). v29 is provisioned with `PlacementAndLoadBalancing/UseMoveCostReports=true` on its local Service Fabric cluster, matching the move-cost behavior being enabled in production.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>